### PR TITLE
chore: upgrade CI workflows and development tooling

### DIFF
--- a/.github/workflows/tests-py.yml
+++ b/.github/workflows/tests-py.yml
@@ -1,0 +1,27 @@
+name: Tests Contract PY
+on: push
+jobs:
+  workflows:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Install Emscripten
+        run: |
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk
+          ./emsdk install latest
+          ./emsdk activate latest
+          source ./emsdk_env.sh
+          echo "PATH=$PATH" >> $GITHUB_ENV
+      - name: Build and test contract
+        run: |
+          cd ./contract-py
+          uv venv
+          uv sync
+          uvx nearc contract.py
+          uv run pytest

--- a/.github/workflows/tests-ts.yml
+++ b/.github/workflows/tests-ts.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "18"
+          node-version: "20"
       - name: Install and test modules
         run: |
           cd ./contract-ts

--- a/contract-rs/Cargo.toml
+++ b/contract-rs/Cargo.toml
@@ -13,11 +13,11 @@ crate-type = ["cdylib", "rlib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-near-sdk = "5.1.0"
+near-sdk = "5.23.0"
 
 [dev-dependencies]
-near-sdk = { version = "5.1.0", features = ["unit-testing"] }
-near-workspaces = { version = "0.16.0", features = ["unstable"] }
+near-sdk = { version = "5.23.0", features = ["unit-testing"] }
+near-workspaces = { version = "0.22.0", features = ["unstable"] }
 tokio = { version = "1.12.0", features = ["full"] }
 serde_json = "1"
 

--- a/contract-rs/rust-toolchain.toml
+++ b/contract-rs/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
-components = ["rustfmt"]
+channel = "1.86.0"
+components = ["rustfmt", "clippy", "rust-analyzer"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Summary
This PR modernizes our CI infrastructure and development tooling across all contract languages.

## Changes
- **Python CI**: New GitHub Actions workflow for testing Python contracts on Ubuntu and macOS
- **TypeScript CI**: Node.js upgrade from v18 to v20
- **Rust Dependencies**: Updated NEAR SDK and workspaces to latest stable versions
- **Rust Toolchain**: Pinned to 1.86.0 with additional development tools
